### PR TITLE
fix(create run): ComfyUIDeployExternalText default value was overwritten

### DIFF
--- a/web/src/server/createRun.ts
+++ b/web/src/server/createRun.ts
@@ -90,12 +90,12 @@ export const createRun = withServerPromise(
         Object.entries(workflow_api).forEach(([_, node]) => {
           if (node.inputs["input_id"] === key) {
             node.inputs["input_id"] = inputs[key];
+            // Fix for external text default value
+            if (node.class_type == "ComfyUIDeployExternalText") {
+              node.inputs["default_value"] = inputs[key];
+            }
           }
 
-          // Fix for external text default value
-          if (node.class_type == "ComfyUIDeployExternalText") {
-            node.inputs["default_value"] = inputs[key];
-          }
         });
       }
     }


### PR DESCRIPTION
Nodes of type `ComfyUIDeployExternalText` were overwritten by others of the same type.

In this function, we populate the workflow API with the prompts written by the user (web form).
Example:
```js
// web form
const inputs = {
  positive_prompt: "a dog",
  negative_prompt: "blurry"
}
```
```json
// worflow_api
{
 "1": {
    "inputs": {
      "input_id": "positive_prompt",
      "default_value": "a house"
    },
    "class_type": "ComfyUIDeployExternalText",
  },
  "2": {
    "inputs": {
      "input_id": "negative_prompt",
      "default_value": "watermark"
    },
    "class_type": "ComfyUIDeployExternalText",
  },
}
```

In this case, at the end, we'll end with something like this because in the second loop iteration (negative_prompt), we are overwriting the `1.inputs.default_value` to be "blurry".
```json
{
 "1": {
    "inputs": {
      "input_id": "a dog",
      "default_value": "blury"
    },
    "class_type": "ComfyUIDeployExternalText",
  },
  "2": {
    "inputs": {
      "input_id": "blury",
      "default_value": "blury"
    },
    "class_type": "ComfyUIDeployExternalText",
  },
}
```
 
