### PR TITLE
fix(workflows): user can click multiple times on run even while loading

### DIFF
--- a/web/src/components/VersionSelect.tsx
+++ b/web/src/components/VersionSelect.tsx
@@ -328,7 +328,7 @@ export function RunWorkflowButton({
             className="px-1"
           >
             <div className="flex justify-end">
-              <AutoFormSubmit>
+              <AutoFormSubmit disabled={isLoading}>
                 Run
                 {isLoading ? <LoadingIcon /> : <Play size={14} />}
               </AutoFormSubmit>


### PR DESCRIPTION
Previously a user was able to click multiple times the run button and create a lot of runs.

https://github.com/BennyKok/comfyui-deploy/assets/31712515/a8c0716b-55de-43e4-9baf-dc28c22664aa

