### PR TITLE
fix(media upload): skip when using the CD_BYPASS_UPLOAD env var

### DIFF
--- a/custom_routes.py
+++ b/custom_routes.py
@@ -990,16 +990,19 @@ async def update_run_with_output(prompt_id, data, node_id=None):
         "run_id": prompt_id,
         "output_data": data
     }
+    have_upload_media = 'images' in data or 'files' in data or 'gifs' in data or 'mesh' in data
+    if bypass_upload and have_upload_media:
+        print("CD_BYPASS_UPLOAD is enabled, skipping the upload of the output:", node_id)
+        return
 
-    if not bypass_upload:
+    if have_upload_media:
         try:
-            have_upload = 'images' in data or 'files' in data or 'gifs' in data or 'mesh' in data
-            print("\nhave_upload", have_upload, node_id)
+            print("\nhave_upload", have_upload_media, node_id)
 
-            if have_upload:
+            if have_upload_media:
                 await update_file_status(prompt_id, data, True, node_id=node_id)
 
-            asyncio.create_task(upload_in_background(prompt_id, data, node_id=node_id, have_upload=have_upload))
+            asyncio.create_task(upload_in_background(prompt_id, data, node_id=node_id, have_upload=have_upload_media))
             # await upload_in_background(prompt_id, data, node_id=node_id, have_upload=have_upload)
 
         except Exception as e:

--- a/custom_routes.py
+++ b/custom_routes.py
@@ -991,7 +991,7 @@ async def update_run_with_output(prompt_id, data, node_id=None):
         "output_data": data
     }
 
-    if not bypass_upload:
+    if bypass_upload == False:
         try:
             have_upload = 'images' in data or 'files' in data or 'gifs' in data or 'mesh' in data
             print("\nhave_upload", have_upload, node_id)

--- a/custom_routes.py
+++ b/custom_routes.py
@@ -991,7 +991,7 @@ async def update_run_with_output(prompt_id, data, node_id=None):
         "output_data": data
     }
 
-    if bypass_upload == False:
+    if not bypass_upload:
         try:
             have_upload = 'images' in data or 'files' in data or 'gifs' in data or 'mesh' in data
             print("\nhave_upload", have_upload, node_id)


### PR DESCRIPTION
fix(upload outputs): skip images/gifs/files/mesh when env var is true

The env var is `CD_BYPASS_UPLOAD`.
When that variable is `True`, we shouldn't upload the media to our comfy
deploy s3 bucket.

There are 2 steps.
1. save the file into our s3 bucket
2. save the output details into our database.


When `CD_BYPASS_UPLOAD` is True:
1. Skip the save file into our s3 bucket
2. Skip the save into our database.

Previously, we were skipping the step 1, but not the step 2. So that is
the reason of why we keep seeing the comfy deploy URL when fetching the
run details:

```
outputs: [
  {
    data:{
      gifs: [
        {
          url: "https://comfy-deploy-output.s3.amazonaws.com/video.mp4"
        }
      ],
      text: [
        "A text that you displayed with show text node"
      ]
    }
  }
]
```

With the new changes we don't save that into our database, and fetching 
the details of a run will look like this:
```
outputs: [
  {
    data:{
      text: [
        "A text that you displayed with show text node"
      ]
    }
  }
]
```

