### PR TITLE
fix: ExternalLoRA node Make downloaded files reusable

### DIFF
--- a/comfy-nodes/external_lora.py
+++ b/comfy-nodes/external_lora.py
@@ -49,7 +49,8 @@ class ComfyUIDeployExternalLora:
                 existing_loras = folder_paths.get_filename_list("loras")
                 # Check if lora_save_name exists in the list
                 if lora_save_name in existing_loras:
-                    raise "LoRA file '{lora_save_name}' already exists."
+                    print(f"using lora: {lora_save_name}")
+                    return (lora_save_name,)
             else:
                 lora_save_name = str(uuid.uuid4()) + ".safetensors"
             print(lora_save_name)


### PR DESCRIPTION
```
if lora_save_name in existing_loras:
                    raise "LoRA file '{lora_save_name}' already exists."
```

This code is raising an error if `default_lora_name` starts with http and the file `lora_save_name` already exists.

This implementation needs to add a part to check if the file has been downloaded externally.

Instead of raising an error, it would be better to use `return (lora_save_name,)` to make the saved file available.