### PR TITLE
feat: Support auth_token on classic machine

### DIFF
--- a/web/src/server/createRun.ts
+++ b/web/src/server/createRun.ts
@@ -196,6 +196,9 @@ export const createRun = withServerPromise(
           const _result = await fetch(comfyui_endpoint, {
             method: "POST",
             body: JSON.stringify(body),
+            headers: {
+              ...(machine.auth_token && {Authorization: `Bearer ${machine.auth_token}`}),
+            },
             cache: "no-store",
           });
           // console.log(_result);


### PR DESCRIPTION
It would also be nice if the Auth Token was also applied to the classic machine.

If you have an auth token, you can add it to the Authorization header.

If this is possible, I think you could implement authentication using the https://github.com/liusida/ComfyUI-Login node.