### PR TITLE
fix(setup): reload the app after adding the localstorage values

### DIFF
--- a/web-plugin/index.js
+++ b/web-plugin/index.js
@@ -755,6 +755,7 @@ const ext = {
           "right",
         );
         localStorage.setItem("Comfy.MenuPosition.Docked", "true");
+        window.location.reload();
         console.log("native mode manmanman");
       } catch (error) {
         console.error("Error setting validation to false", error);


### PR DESCRIPTION
The current problem is that if you do `localsStorage.setItem()` the value is changed, but comfyUI doesn't detect the change because `ComfyActionbar` was already mounted.

This is a quick fix where we basically trigger a reload of the app after docking the menu position.